### PR TITLE
feat(tools): add orhun/git-cliff

### DIFF
--- a/aqua-config/all.yaml
+++ b/aqua-config/all.yaml
@@ -23,3 +23,4 @@ packages:
   - name: jesseduffield/lazygit@v0.48.0
   - name: junegunn/fzf@v0.61.1
   - name: noahgorstein/jqp@v0.7.0
+  - name: orhun/git-cliff@v2.8.0


### PR DESCRIPTION
This pull request includes a small change to the `aqua-config/all.yaml` file. The change adds a new tool, `orhun/git-cliff@v2.8.0`, to the configuration.

* [`aqua-config/all.yaml`](diffhunk://#diff-4ba22f390a7f20df6d784aac93500a32d5b1ac58e2bceee9619fd230f4ff415bR26): Added `orhun/git-cliff@v2.8.0` to the list of tools.